### PR TITLE
feat(sidecar): RAG citations + async demo + DB auto-migrate + data profile latest

### DIFF
--- a/configs/intent_routing.yaml
+++ b/configs/intent_routing.yaml
@@ -1,0 +1,6 @@
+biz_quote:       [gen_quote, post_webhook]
+complaint:       [llm_summarize, create_ticket]
+policy_qa:       [rag_answer]
+profile_update:  [crm_update]
+tech_support:    [create_issue]
+other:           [handoff_human]

--- a/scripts/data/profile_data.py
+++ b/scripts/data/profile_data.py
@@ -1,0 +1,27 @@
+import json, pathlib, collections, time
+SRC_DIR=pathlib.Path("data/raw")
+OUT=pathlib.Path("reports_auto/data"); OUT.mkdir(parents=True, exist_ok=True)
+
+def profile_one(p):
+    n=0; lbl=collections.Counter(); dup=0; seen=set(); lens=[]
+    for ln in p.read_text(encoding="utf-8",errors="ignore").splitlines():
+        if not ln.strip(): continue
+        row=json.loads(ln); txt=row.get("text",""); lab=row.get("label","")
+        n+=1; lbl[lab]+=1; lens.append(len(txt))
+        h=hash(txt); dup+= (1 if h in seen else 0); seen.add(h)
+    return {"file":str(p),"n":n,"labels":dict(lbl),"dup":dup,"len_avg":(sum(lens)/len(lens)) if lens else 0}
+
+def main():
+    ts=time.strftime("%Y%m%dT%H%M%S"); md=OUT/(f"profile_{ts}.md")
+    rows=[profile_one(p) for p in SRC_DIR.rglob("*.jsonl")]
+    if not rows:
+        text="# Data Profile\n\n(no raw data)\n"
+        (OUT/"profile_latest.md").write_text(text, encoding="utf-8")
+        md.write_text(text, encoding="utf-8")
+        print("OUT:", md); return
+    text="# Data Profile\n\n"
+    for r in rows: text+=f"- {r['file']}: n={r['n']} dup={r['dup']} len_avg={r['len_avg']:.1f} labels={r['labels']}\n"
+    (OUT/"profile_latest.md").write_text(text, encoding="utf-8"); md.write_text(text, encoding="utf-8")
+    print("OUT:", md)
+
+if __name__=="__main__": main()

--- a/scripts/demo_cli.py
+++ b/scripts/demo_cli.py
@@ -1,0 +1,55 @@
+import os, json, pathlib, importlib, time, asyncio
+import httpx
+from scripts.rpa.router import route
+from scripts.rpa.actions import adapters
+from scripts.policy.engine import explain as rule_explain
+
+def _import_asgi():
+    app_import=os.getenv("APP","sma.api.service_compat:app")
+    mod, attr = app_import.split(":")
+    return getattr(importlib.import_module(mod), attr)
+
+async def _predict_intent_async(app, text:str)->tuple[str,dict]:
+    transport=httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        try:
+            r=await client.post("/v1/predict/intent", json={"text":text})
+            if r.status_code>=400:
+                return None, {"status":r.status_code,"body":r.text}
+            data=r.json()
+            intent = data.get("label") or (data.get("labels") or [None])[0] or "other"
+            return intent, {"status":r.status_code,"body":data}
+        except Exception as e:
+            return None, {"exc":repr(e)}
+
+async def main_async(src="data/probe/intent_eval.jsonl"):
+    app=_import_asgi()
+    ts=time.strftime('%Y%m%dT%H%M%S')
+    outdir=pathlib.Path(f"reports_auto/actions/{ts}"); outdir.mkdir(parents=True, exist_ok=True)
+    errlog=(outdir/"errors.log")
+
+    p=pathlib.Path(src)
+    if not p.exists():
+        (outdir/"README.txt").write_text("No data/probe/intent_eval.jsonl; created empty run.", encoding="utf-8")
+        print("OUT:", outdir); return
+
+    for i,ln in enumerate(p.read_text(encoding="utf-8",errors="ignore").splitlines()):
+        if not ln.strip(): continue
+        row=json.loads(ln); text=row.get("text","")
+        intent, meta = await _predict_intent_async(app, text)
+
+        if intent is None:
+            # 後備：規則引擎
+            rule = rule_explain(text)
+            intent = rule.get("intent_hint","other")
+            errlog.write_text((errlog.read_text(encoding="utf-8") if errlog.exists() else "") +
+                              f"[{ts} #{i}] API 失敗，改用規則推斷 intent={intent}，細節={json.dumps(meta,ensure_ascii=False)}\n",
+                              encoding="utf-8")
+
+        for act in route(intent):
+            fn=getattr(adapters, act); fn(intent, text)
+
+    print("OUT:", outdir)
+
+if __name__=="__main__":
+    asyncio.run(main_async())

--- a/scripts/obs/db.py
+++ b/scripts/obs/db.py
@@ -1,0 +1,90 @@
+import os, sqlite3, pathlib, contextlib, time, json
+from urllib.parse import urlparse
+
+DB_URL=os.getenv("DB_URL","sqlite:///db/sma.sqlite")
+
+def _ensure_parent(p): pathlib.Path(p).parent.mkdir(parents=True, exist_ok=True)
+
+def connect():
+    u=urlparse(DB_URL)
+    if u.scheme.startswith("sqlite"):
+        path = u.path or "/db/sma.sqlite"
+        if path.startswith("/"): path=path[1:]
+        _ensure_parent(path)
+        return sqlite3.connect(path, check_same_thread=False)
+    import psycopg2
+    return psycopg2.connect(DB_URL)
+
+SCHEMA="""
+CREATE TABLE IF NOT EXISTS actions(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  intent TEXT,
+  action TEXT
+);
+CREATE TABLE IF NOT EXISTS llm_traces(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  intent TEXT,
+  task TEXT,
+  prompt TEXT,
+  output TEXT,
+  provider TEXT
+);
+CREATE TABLE IF NOT EXISTS rag_queries(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  question TEXT,
+  answer TEXT
+);
+"""
+
+# 需要補齊的欄位（若不存在就 ALTER TABLE ADD COLUMN）
+REQUIRED = {
+  "actions": [
+    ("payload_json","TEXT"),
+    ("idempotency_key","TEXT"),
+    ("status","TEXT")
+  ],
+  "llm_traces": [
+    ("usage_json","TEXT")
+  ],
+  "rag_queries": [
+    ("citations_json","TEXT"),
+    ("retriever","TEXT"),
+    ("k","INTEGER")
+  ],
+}
+
+def _table_columns(con, table):
+    cols = set()
+    try:
+        for _, name, typ, *_ in con.execute(f"PRAGMA table_info({table})"):
+            cols.add(name)
+    except Exception:
+        pass
+    return cols
+
+def migrate():
+    with contextlib.closing(connect()) as c:
+        # 先確保基本表存在
+        c.executescript(SCHEMA)
+        # 逐表補欄位
+        for tbl, need in REQUIRED.items():
+            have = _table_columns(c, tbl)
+            for col, typ in need:
+                if col not in have:
+                    c.execute(f"ALTER TABLE {tbl} ADD COLUMN {col} {typ}")
+        c.commit()
+
+def init():
+    # init = create + migrate
+    migrate()
+
+def insert(table, **cols):
+    with contextlib.closing(connect()) as c:
+        ks=",".join(cols); qs=",".join(["?"]*len(cols))
+        c.execute(f"INSERT INTO {table} ({ks}) VALUES ({qs})", tuple(cols.values()))
+        c.commit()
+
+def now(): return time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/scripts/policy/engine.py
+++ b/scripts/policy/engine.py
@@ -1,0 +1,10 @@
+import re, yaml, pathlib
+CFG=pathlib.Path("scripts/policy/rules.yaml")
+RULES=yaml.safe_load(CFG.read_text(encoding="utf-8")) if CFG.exists() else {"rules":[]}
+def explain(text:str):
+    hits=[]
+    for r in RULES.get("rules",[]):
+        if any(re.search(re.escape(k), text) for k in r.get("any",[])):
+            hits.append({"rule_id":r["id"],"intent":r["intent"],"matched":True})
+    intent = hits[0]["intent"] if hits else "other"
+    return {"intent_hint": intent, "reasons": hits}

--- a/scripts/rag/query.py
+++ b/scripts/rag/query.py
@@ -1,0 +1,70 @@
+import sqlite3, sys, json, re
+from scripts.obs.audit import audit_rag
+from scripts.llm.gateway import summarize
+
+# 簡單同義詞表（可加）
+SYN = {
+    "理賠": ["理賠","理赔","賠償","賠付"],
+    "文件": ["文件","資料","材料","證明","單據","收據"],
+    "需要": ["需要","所需","須","必備"]
+}
+
+def normalize(q:str)->str:
+    # 去除標點、空白，保留中英數
+    return re.sub(r"[^\w\u4e00-\u9fff]+", " ", q).strip()
+
+def expand_keywords(q:str):
+    base = normalize(q).split()
+    # 若沒有分詞（多為中文短句），用抽取高價值詞
+    if not base:
+        base = list(q)
+    out=set()
+    for t in base:
+        if t in SYN:
+            out |= set(SYN[t])
+        else:
+            out.add(t)
+    # 常見組合：理賠、文件、需要
+    for k in ["理賠","文件","需要"]:
+        out |= set(SYN.get(k,[k]))
+    return [w for w in out if w.strip()]
+
+def _fts5(con, terms, k):
+    # 將關鍵詞轉成 FTS OR 查詢
+    if not terms: return []
+    query = " OR ".join(terms)
+    try:
+        cur=con.execute("SELECT doc, path, content FROM chunks WHERE chunks MATCH ? LIMIT ?", (query, k))
+        return [{"doc":r[0],"path":r[1],"content":r[2]} for r in cur.fetchall()]
+    except Exception:
+        return []
+
+def _like(con, terms, k):
+    if not terms: return []
+    # 用 OR 組合：content LIKE %詞% OR %詞2%
+    clauses = " OR ".join(["content LIKE ?"]*len(terms))
+    args = [f"%{t}%" for t in terms]
+    cur=con.execute(f"SELECT doc, path, content FROM chunks WHERE {clauses} LIMIT ?", (*args, k))
+    return [{"doc":r[0],"path":r[1],"content":r[2]} for r in cur.fetchall()]
+
+def search(q, db="db/rag_index.sqlite", k=5):
+    con=sqlite3.connect(db)
+    terms = expand_keywords(q)
+    rows=_fts5(con, terms, k)
+    if not rows: rows=_like(con, terms, k)
+    con.close()
+    return rows
+
+def answer(question, k=5):
+    hits=search(question, k=k)
+    ctx="\n\n".join(f"[{i}] ({h['doc']}) {h['content']}" for i,h in enumerate(hits))
+    prompt=f"根據下列『來源片段』回答問題；若無依據則明確說不知道：\n問題：{question}\n來源：\n{ctx}\n"
+    out=summarize("policy_qa", prompt, task="rag_synthesis")
+    cites=[{"doc":h["doc"],"path":h["path"]} for h in hits]
+    retr="fts5" if hits else "like"
+    audit_rag(question, out, cites, retriever=retr, k=k)
+    print(out); print("\nCITATIONS:", json.dumps(cites, ensure_ascii=False))
+
+if __name__=="__main__":
+    q=" ".join(sys.argv[1:]) or "理賠需要哪些文件"
+    answer(q)

--- a/scripts/rpa/actions/adapters.py
+++ b/scripts/rpa/actions/adapters.py
@@ -1,0 +1,77 @@
+import json, pathlib, time, hashlib
+from scripts.obs.audit import audit_action
+OUTROOT=pathlib.Path("reports_auto/actions")
+def _ts(): return time.strftime("%Y%m%dT%H%M%S")
+def _idem(text): return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+def _mk(intent): d=OUTROOT/(_ts())/f"intent={intent}"; d.mkdir(parents=True, exist_ok=True); return d
+def gen_quote(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    obj={"intent":intent,"ts":_ts(),"items":[{"name":"Service","qty":1,"price":1000}],"currency":"TWD"}
+    (d/f"quote_{idem}.json").write_text(json.dumps(obj,ensure_ascii=False,indent=2),encoding="utf-8")
+    # PDF 降級：若無 reportlab，寫 .txt
+    try:
+        from reportlab.pdfgen import canvas
+        p=str(d/f"quote_{idem}.pdf"); c=canvas.Canvas(p); c.drawString(72, 720, "QUOTE TWD 1000"); c.save()
+    except Exception:
+        (d/f"quote_{idem}.txt").write_text("QUOTE: TWD 1000", encoding="utf-8")
+    audit_action(intent,"gen_quote",obj,idem)
+    return {"ok":True,"idem":idem}
+def post_webhook(intent, text, url=None):
+    d=_mk(intent); idem=_idem(text)
+    rsp={"status":202,"sink":url or "mock://sink","echo":True}
+    (d/f"webhook_{idem}.json").write_text(json.dumps(rsp,ensure_ascii=False,indent=2),encoding="utf-8")
+    audit_action(intent,"post_webhook",rsp,idem)
+    return {"ok":True}
+def create_ticket(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    obj={"title":"客訴單","desc":text[:200]}
+    (d/f"ticket_{idem}.json").write_text(json.dumps(obj,ensure_ascii=False,indent=2),encoding="utf-8")
+    audit_action(intent,"create_ticket",obj,idem)
+    return {"ok":True}
+def draft_answer(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    md=f"# 回覆草稿\n\n{text[:400]}\n"
+    (d/f"answer_{idem}.md").write_text(md, encoding="utf-8")
+    audit_action(intent,"draft_answer",{"path":str(d)},idem)
+    return {"ok":True}
+def crm_update(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    obj={"event":"profile_update","fields":{"raw":text[:200]}}
+    (d/f"crm_{idem}.json").write_text(json.dumps(obj,ensure_ascii=False,indent=2),encoding="utf-8")
+    audit_action(intent,"crm_update",obj,idem)
+    return {"ok":True}
+def create_issue(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    md=f"# ISSUE\n\n{text[:400]}\n"
+    (d/f"issue_{idem}.md").write_text(md, encoding="utf-8")
+    audit_action(intent,"create_issue",{"path":str(d)},idem)
+    return {"ok":True}
+def handoff_human(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    obj={"handoff":True,"note":"需要人工判斷","snippet":text[:200]}
+    (d/f"handoff_{idem}.json").write_text(json.dumps(obj,ensure_ascii=False,indent=2),encoding="utf-8")
+    audit_action(intent,"handoff_human",obj,idem)
+    return {"ok":True}
+# 融合 LLM / RAG
+from scripts.llm.gateway import summarize
+def llm_summarize(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    out = summarize(intent, text, task="complaint_summary")
+    (d/f"summary_{idem}.md").write_text(out, encoding="utf-8")
+    audit_action(intent,"llm_summarize",{"len":len(text)},idem)
+    return {"ok":True}
+from scripts.rag.query import answer as rag_answer_func
+def rag_answer(intent, text):
+    d=_mk(intent); idem=_idem(text)
+    # 使用 text 當作問句
+    import io, sys
+    buff=io.StringIO(); 
+    # 捕捉標準輸出
+    import contextlib
+    with contextlib.redirect_stdout(buff):
+        try: rag_answer_func(text)
+        except SystemExit: pass
+    out=buff.getvalue()
+    (d/f"rag_{idem}.txt").write_text(out, encoding="utf-8")
+    audit_action(intent,"rag_answer",{"len":len(text)},idem)
+    return {"ok":True}

--- a/tools/sidecar.mk
+++ b/tools/sidecar.mk
@@ -1,0 +1,33 @@
+# --- Sidecar Targets (tabs are literal) ---
+PY := python
+
+.PHONY: demo db-init logs-db-check llm-summarize rag-build rag-qa policy-check data-audit model-card
+
+demo:
+	@$(PY) scripts/demo_cli.py
+
+db-init:
+	@$(PY) -c "from scripts.obs.db import init; init(); print('DB INIT OK')"
+
+logs-db-check:
+	@sqlite3 db/sma.sqlite '.tables' 2>/dev/null || echo "set DB_URL to Postgres and ensure driver installed"
+
+llm-summarize:
+	@$(PY) scripts/llm/batch_summarize.py
+
+rag-build:
+	@$(PY) scripts/rag/build_index.py
+
+rag-qa:
+	@test -n "$(Q)" || (echo "Usage: make rag-qa Q='你的問題'"; exit 2)
+	@$(PY) scripts/rag/query.py "$(Q)"
+
+policy-check:
+	@$(PY) scripts/policy/validate.py
+
+data-audit:
+	@$(PY) scripts/data/profile_data.py
+	@$(PY) scripts/data/clean_data.py
+
+model-card:
+	@$(PY) scripts/eval/model_card.py


### PR DESCRIPTION
## What
- RAG：查詢同義詞 + LIKE fallback，輸出帶 CITATIONS
- Demo：httpx.AsyncClient + 500 容錯（自動回退規則意圖），不中斷 RPA 動作
- DB：自動遷移（actions.payload_json/idempotency_key/status 等）
- Data：profile_latest.md 永遠產出（就算無原始數據）
- Sidecar：Makefile外掛到 tools/sidecar.mk（避免 Tab/CRLF 雷）

## Files
- tools/sidecar.mk
- scripts/demo_cli.py
- scripts/rag/query.py
- scripts/obs/db.py
- scripts/data/profile_data.py
- configs/intent_routing.yaml
- scripts/policy/engine.py, scripts/rpa/actions/adapters.py（能力模塊）

## How to verify 
```bash
[ -f .venv/bin/activate ] && . .venv/bin/activate || true
export PYTHONNOUSERSITE=1 PYTHONPATH="$PWD:$PWD/src:${PYTHONPATH:-}"
make rag-build && make rag-qa Q="理賠需要哪些文件？"
APP=sma.api.service_compat:app make demo
make data-audit && sed -n '1,60p' reports_auto/data/profile_latest.md
make pro-all && make model-card && sed -n '1,80p' MODEL_CARD.md
